### PR TITLE
Delete enable_openstack_repository.sh

### DIFF
--- a/playbooks/roles/common/files/enable_openstack_repository.sh
+++ b/playbooks/roles/common/files/enable_openstack_repository.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "deb http://ubuntu-cloud.archive.canonical.com/ubuntu" "trusty-updates/liberty main" > /etc/apt/sources.list.d/cloudarchive-liberty.list
-


### PR DESCRIPTION
Now add-apt-repository is used to enable openstack repository
instead of enable_openstack_repository.sh.
